### PR TITLE
新增 Lua 脚本缓存策略，以及为项目内所有 I/O 密集型操作配置统一的调度器

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <dependency>
     <groupId>org.redisson</groupId>
     <artifactId>redisson</artifactId>
-    <version>3.51.0</version> <!-- 当前最新版本 -->
+    <version>3.52.0</version> <!-- 当前最新版本 -->
 </dependency>
 ```
 
@@ -19,22 +19,22 @@
 
 当前该依赖已经发布至 Maven 的中央仓库，可以访问：[Redis_Lock](https://central.sonatype.com/artifact/io.github.jessez332623/redis_lock)，也可以在 pom.xml 中直接配置：
 
-### 📢 重要通知
-
-不要使用 `1.0.0` ~ `1.0.2` 版本，它们是有问题的，具体信息见：
-
-- [修复文档-1.0.2 分布式公平信号量键在 Redis 集群中的适配](https://github.com/JesseZ332623/Redis-Distributed-Lock/blob/main/documents/%E7%89%88%E6%9C%AC%201.0.2%20%E4%BF%AE%E5%A4%8D.md)
-- [修复文档-1.0.5 模块化迁移，以及更简易、更安全的上下文配置](https://github.com/JesseZ332623/Redis-Distributed-Lock/blob/main/documents/%E7%89%88%E6%9C%AC%201.0.5%20%E4%BF%AE%E5%A4%8D.md)
-
----
-
 ```XML
 <dependency>
     <groupId>io.github.jessez332623</groupId>
     <artifactId>redis_lock</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 </dependency>
 ```
+
+### 📢 重要通知
+
+不要使用 `1.0.0` ~ `1.0.5` 版本，它们是有问题或者性能不佳的，具体信息见：
+
+- [修复文档-1.0.2 分布式公平信号量键在 Redis 集群中的适配](https://github.com/JesseZ332623/Redis-Distributed-Lock/blob/main/documents/%E7%89%88%E6%9C%AC%201.0.2%20%E4%BF%AE%E5%A4%8D.md)
+- [修复文档-1.0.5 模块化迁移，以及更简易、更安全的上下文配置](https://github.com/JesseZ332623/Redis-Distributed-Lock/blob/main/documents/%E7%89%88%E6%9C%AC%201.0.5%20%E4%BF%AE%E5%A4%8D.md)
+- [更新文档-1.0.6 Lua 脚本缓存策略，以及为所有锁操作配置统一的调度器]()
+---
 
 ### 上下文配置
 
@@ -109,15 +109,31 @@ public class ReactiveRedisConfig
 
 ### 属性配置
 
-```properties
-# 禁用本依赖（默认开启）
-app.redis-lock.enabled=false
+```yml
+app:
+  redis-lock:
+    # 是否禁用本依赖（默认开启）
+    enable: true
 
-# 设置分布式锁键的键前缀为：project-lock（默认为 lock）
-app.redis-lock.distributed-lock.key-prefix=project-lock
-
-# 设置分布式公平信号量键的键前缀为：project-semaphore（默认为 semaphore）
-app.redis-lock.fair-semaphore.key-prefix=project-semaphore
+    schedulers:
+      # 最大线程数（默认 100 线程）
+      max-threads: 100
+      # 任务队列容量（默认 1000）
+      task-queue-capacity: 1000
+      # 调度线程名（默认 redis-lock）
+      thread-name: redis-lock
+      # 空闲线程存活时间（默认 60 秒）
+      ttl-seconds: 60
+      # 是否开启守护线程？（对于分布式锁操作来说是必须的）
+      daemon: true
+    
+    distributed-lock:
+      # 设置分布式锁键的键前缀为：project-lock（默认为 lock）
+      key-prefix: project-lock
+      
+    fair-semaphore:
+      # 设置分布式公平信号量键的键前缀为：project-semaphore（默认为 semaphore）
+      key-prefix: project-semaphore
 ```
 
 ## 代码速览
@@ -138,4 +154,4 @@ app.redis-lock.fair-semaphore.key-prefix=project-semaphore
 
 ## Latest Update
 
-*2025.09.28*
+*2025.11.10*

--- a/documents/版本 1.0.6 更新说明.md
+++ b/documents/版本 1.0.6 更新说明.md
@@ -1,0 +1,179 @@
+# 版本 1.0.6 更新说明
+
+## 1.  新增 Lua 脚本缓存策略
+
+原来的 `LuaScriptReader` 没有实现缓存 `DefaultRedisScript<LuaOperatorResult>` 实例的策略，在高并发的情况下会频繁的去文件系统中读取脚本，这会成为性能瓶颈，所以我增加了缓存机制，确保脚本实例不会被反复读取。核心代码如下所示：
+
+```java
+final public class LuaScriptReader 
+{
+      /** ... */
+      /** Lua 脚本缓存：operatorType -> (scriptName -> script) */
+     private final ConcurrentMap<
+         LuaScriptOperatorType,
+         ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>>
+         scriptCache = new ConcurrentHashMap<>();
+
+     @Autowired
+     @Qualifier("distributedLockScheduler")
+     private Scheduler scheduler;
+
+      /** 获取或者创建指定操作类型的脚本缓存。*/
+    private ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
+    getOrCreateScriptCache(LuaScriptOperatorType scriptOperatorType)
+    {
+        return
+        this.scriptCache.computeIfAbsent(
+            scriptOperatorType,
+            (scriptName) -> new ConcurrentHashMap<>()
+        );
+    }
+
+    /**
+     * 通过操作类型 + 脚本名尝试从缓存中获取指定的
+     * {@link DefaultRedisScript<LuaOperatorResult>}，没有则从 classpath 中加载然后缓存。
+     *
+     * @param operatorType  Lua 脚本类型
+     * @param luaScriptName Lua 脚本名
+     *
+     * @return 由 {@link DefaultRedisScript} 包装的，
+     *         发布 Lua 脚本执行结果 {@link LuaOperatorResult} 的 {@link Mono}
+     */
+    private @NotNull Mono<DefaultRedisScript<LuaOperatorResult>>
+    getScriptFromCache(LuaScriptOperatorType operatorType, String luaScriptName)
+    {
+        return
+        Mono.fromCallable(() -> {
+            ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
+                operatorCache = this.getOrCreateScriptCache(operatorType);
+
+            // 调用 computeIfAbsent() 方法，
+            // 存在则直接返回，不存在执行 mappingFunction 缓存后再返回。
+            return
+            operatorCache.computeIfAbsent(
+                luaScriptName,
+                (scriptName) -> {
+                    try
+                    {
+                        return
+                        this.loadFromClassPath(operatorType, luaScriptName);
+                    }
+                    catch (IOException exception)
+                    {
+                        throw new
+                        LuaScriptOperatorFailed(
+                            format(
+                                "Load lua script %s failed! Caused by: %s",
+                                luaScriptName, exception.getMessage()),
+                            exception
+                        );
+                    }
+                }
+            );
+        });
+    }
+    /** ... */
+}
+```
+
+## 2.  为项目内所有 I/O 密集型操作配置统一的调度器
+
+在原来的代码中，没有为 Lua 脚本读取、Lua 脚本执行这样的 I/O 操作配置调度器，
+按照响应式架构的设计，对于没有指定调度器的响应式流，订阅后一般由事件循环线程（ioEventLoop）执行，显然让宝贵的事件循环线程去执行 I/O 操作是不合理的，所以我为本项目配置了专用的调度器，如下所示：
+
+```java
+    /** Redis Lock 专用的线程调度器 Bean。*/
+    @Bean(name = "distributedLockScheduler")
+    public Scheduler
+    distributedLockScheduler(RedisLockProperties properties)
+    {
+        RedisLockProperties.ProjectSchedulersProperties
+            schedulersProperties = properties.getSchedulers();
+
+        return
+        Schedulers.newBoundedElastic(
+            schedulersProperties.getMaxThreads(),
+            schedulersProperties.getTaskQueueCapacity(),
+            schedulersProperties.getThreadName(),
+            schedulersProperties.getTtlSeconds(),
+            schedulersProperties.isDaemon()
+        );
+    }
+```
+
+用户可以根据自己项目的负载程度在配置中自定义调度器的相关参数，示例如下：
+
+```yml
+app:
+  redis-lock:
+    schedulers:
+      # 最大线程数（默认 100 线程）
+      max-threads: 100
+      # 任务队列容量（默认 1000）
+      task-queue-capacity: 1000
+      # 调度线程名（默认 redis-lock）
+      thread-name: redis-lock
+      # 空闲线程存活时间（默认 60 秒）
+      ttl-seconds: 60
+      # 是否开启守护线程？（对于分布式锁操作来说是必须的）
+      daemon: true
+```
+
+这个调度器被用在了某些关键的位置，关键代码如下所示：
+
+```java
+   /**
+     * 尝试获取一个锁。
+     *
+     * @param lockName          锁名
+     * @param acquireTimeout    获取锁的时间期限
+     * @param lockTimeout       锁本身的有效期（单位：秒）
+     *
+     * @return 返回一个 Mono，成功获取锁时发布锁的唯一标识符（UUID）
+     */
+    private @NotNull Mono<String>
+    acquireLockTimeout(
+        String lockName, long acquireTimeout, long lockTimeout)
+    {
+        final String lockKeyName = getRedisLockKey(lockName);
+        final String identifier  = UUID.randomUUID().toString();
+
+        return
+        this.luaScriptReader
+            .read(DISTRIBUTE_LOCK, "acquireLockTimeout.lua") // Lua 脚本执行在指定调度器
+            .flatMap((script) ->
+                this.scriptRedisTemplate
+                    .execute(
+                        script,
+                        List.of(lockKeyName),
+                        identifier, acquireTimeout, lockTimeout)
+                    .next()
+                    .subscribeOn(this.scheduler) // Lua 脚本执行在指定调度器
+                    .flatMap((result) ->
+                        switch (result.getResult())
+                        {
+                            case "GET_LOCK_TIMEOUT" ->
+                                Mono.error(
+                                    new RedisDistributedLockAcquireTimeout(
+                                        format(
+                                            "Acquire lock: %s timeout! (acquireTimeout = %d seconds)",
+                                            lockName, acquireTimeout
+                                        )
+                                    )
+                                );
+
+                            case "SUCCESS" -> Mono.just(identifier);
+
+                            case null, default ->
+                                Mono.error(
+                                    new IllegalStateException(
+                                        "Unexpected value: " + result.getResult()
+                                    )
+                                );
+                        }
+                    )
+            ).onErrorResume(RedisLockErrorHandle::redisLockGenericErrorHandle);
+    }
+```
+
+*2025.11.07*

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.jessez332623</groupId>
 	<artifactId>redis_lock</artifactId>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 	<name>redis_lock</name>
 	<description>基于 Redis 且无缝集成响应式编程的互斥锁和公平信号量实现</description>
     <url>https://github.com/JesseZ332623/Redis-Distributed-Lock</url>

--- a/src/main/java/io/github/jessez332623/redis_lock/autoconfigure/RedisLockProperties.java
+++ b/src/main/java/io/github/jessez332623/redis_lock/autoconfigure/RedisLockProperties.java
@@ -12,6 +12,10 @@ public class RedisLockProperties
     /** 是否启用本依赖？（默认启用）*/
     private boolean enabled = true;
 
+    /** 项目 I/O 密集型操作通用调度器相关属性配置。*/
+    private ProjectSchedulersProperties schedulers
+        = new ProjectSchedulersProperties();
+
     /** Redis 分布式锁相关属性配置 */
     private DistributedLockProperties distributedLock
         = new DistributedLockProperties();
@@ -34,5 +38,25 @@ public class RedisLockProperties
     {
         /** 公平信号量键的键前缀（用户自定义，默认为 semaphore）。*/
         private String keyPrefix = "semaphore";
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class ProjectSchedulersProperties
+    {
+        /** 最大线程数（默认 100 线程）*/
+        private int maxThreads = 100;
+
+        /** 任务队列容量（默认 1000）*/
+        private int taskQueueCapacity = 1000;
+
+        /** 调度线程名（默认 redis-lock）*/
+        private String threadName = "redis-lock";
+
+        /** 空闲线程存活时间（默认 60 秒）*/
+        private int ttlSeconds = 60;
+
+        /* 是否开启守护线程？（对于分布式锁操作来说是必须的）*/
+        private boolean daemon = true;
     }
 }

--- a/src/main/java/io/github/jessez332623/redis_lock/error_handle/RedisLockErrorHandle.java
+++ b/src/main/java/io/github/jessez332623/redis_lock/error_handle/RedisLockErrorHandle.java
@@ -1,7 +1,6 @@
 package io.github.jessez332623.redis_lock.error_handle;
 
 import io.github.jessez332623.redis_lock.utils.exception.LuaScriptOperatorFailed;
-// import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +27,7 @@ final public class RedisLockErrorHandle
      * @return 发布异常或者默认值的 Mono
      */
     public static <T> @NotNull Mono<T>
-    redisLockGenericErrorHandel(@NotNull Throwable exception)
+    redisLockGenericErrorHandle(@NotNull Throwable exception)
     {
         if (isLettuceTimeoutException(exception)) {
             return Mono.error(exception);

--- a/src/main/java/io/github/jessez332623/redis_lock/utils/LuaScriptReader.java
+++ b/src/main/java/io/github/jessez332623/redis_lock/utils/LuaScriptReader.java
@@ -6,13 +6,18 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static java.lang.String.format;
 
@@ -26,15 +31,24 @@ final public class LuaScriptReader
     private static final String
     LUA_SCRIPT_CLASSPATH_PREFIX = "lua-script";
 
+    /** Lua 脚本缓存：operatorType -> (scriptName -> script) */
+    private final ConcurrentMap<
+        LuaScriptOperatorType,
+        ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>>
+        scriptCache = new ConcurrentHashMap<>();
+
+    @Autowired
+    @Qualifier("distributedLockScheduler")
+    private Scheduler scheduler;
+
     /** 从 classpath 中加载脚本。*/
     @Contract("_, _ -> new")
     private @NotNull
     DefaultRedisScript<LuaOperatorResult>
-    loadFromClassPath(
-        @NotNull LuaScriptOperatorType operatorType,
-        String luaScriptName
-    ) throws IOException
+    loadFromClassPath(@NotNull LuaScriptOperatorType operatorType, String luaScriptName) throws IOException
     {
+        // 拼接 Lua 脚本的 classpath，
+        // 格式：lua-script/{operator-type}/{script-name.lua}
         final String scriptClasspath
             = LUA_SCRIPT_CLASSPATH_PREFIX       +
               "/" + operatorType.getTypeName()  +
@@ -61,30 +75,75 @@ final public class LuaScriptReader
         }
     }
 
+    /** 获取或者创建指定操作类型的脚本缓存。*/
+    private ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
+    getOrCreateScriptCache(LuaScriptOperatorType scriptOperatorType)
+    {
+        return
+        this.scriptCache.computeIfAbsent(
+            scriptOperatorType,
+            (scriptName) -> new ConcurrentHashMap<>()
+        );
+    }
+
     /**
-     * 根据配置，从 classpath 读取脚本并包装。
+     * 通过操作类型 + 脚本名尝试从缓存中获取指定的
+     * {@link DefaultRedisScript<LuaOperatorResult>}，没有则从 classpath 中加载然后缓存。
      *
      * @param operatorType  Lua 脚本类型
      * @param luaScriptName Lua 脚本名
      *
-     * @return 由 {@link  DefaultRedisScript} 包装的，
+     * @return 由 {@link DefaultRedisScript} 包装的，
+     *         发布 Lua 脚本执行结果 {@link LuaOperatorResult} 的 {@link Mono}
+     */
+    private @NotNull Mono<DefaultRedisScript<LuaOperatorResult>>
+    getScriptFromCache(LuaScriptOperatorType operatorType, String luaScriptName)
+    {
+        return
+        Mono.fromCallable(() -> {
+            ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
+                operatorCache = this.getOrCreateScriptCache(operatorType);
+
+            // 调用 computeIfAbsent() 方法，
+            // 存在则直接返回，不存在执行 mappingFunction 缓存后再返回。
+            return
+            operatorCache.computeIfAbsent(
+                luaScriptName,
+                (scriptName) -> {
+                    try
+                    {
+                        return
+                        this.loadFromClassPath(operatorType, luaScriptName);
+                    }
+                    catch (IOException exception)
+                    {
+                        throw new
+                        LuaScriptOperatorFailed(
+                            format(
+                                "Load lua script %s failed! Caused by: %s",
+                                luaScriptName, exception.getMessage()),
+                            exception
+                        );
+                    }
+                }
+            );
+        });
+    }
+
+    /**
+     * 根据配置，读取 Lua 脚本并包装。
+     *
+     * @param operatorType  Lua 脚本类型
+     * @param luaScriptName Lua 脚本名
+     *
+     * @return 由 {@link DefaultRedisScript} 包装的，
      *         发布 Lua 脚本执行结果 {@link LuaOperatorResult} 的 {@link Mono}
      */
     public @NotNull Mono<DefaultRedisScript<LuaOperatorResult>>
     read(LuaScriptOperatorType operatorType, String luaScriptName)
     {
         return
-        Mono.fromCallable(() ->
-            this.loadFromClassPath(operatorType, luaScriptName))
-        .onErrorMap(
-            IOException.class,
-            (exception) ->
-                new LuaScriptOperatorFailed(
-                    format(
-                        "Load lua script %s failed! Caused by: %s",
-                        luaScriptName, exception.getMessage()),
-                    exception
-                )
-        );
+        this.getScriptFromCache(operatorType, luaScriptName)
+            .subscribeOn(this.scheduler);
     }
 }


### PR DESCRIPTION
# 版本 1.0.6 更新说明

## 1.  新增 Lua 脚本缓存策略

原来的 `LuaScriptReader` 没有实现缓存 `DefaultRedisScript<LuaOperatorResult>` 实例的策略，在高并发的情况下会频繁的去文件系统中读取脚本，这会成为性能瓶颈，所以我增加了缓存机制，确保脚本实例不会被反复读取。核心代码如下所示：

```java
final public class LuaScriptReader 
{
      /** ... */
      /** Lua 脚本缓存：operatorType -> (scriptName -> script) */
     private final ConcurrentMap<
         LuaScriptOperatorType,
         ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>>
         scriptCache = new ConcurrentHashMap<>();

     @Autowired
     @Qualifier("distributedLockScheduler")
     private Scheduler scheduler;

      /** 获取或者创建指定操作类型的脚本缓存。*/
    private ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
    getOrCreateScriptCache(LuaScriptOperatorType scriptOperatorType)
    {
        return
        this.scriptCache.computeIfAbsent(
            scriptOperatorType,
            (scriptName) -> new ConcurrentHashMap<>()
        );
    }

    /**
     * 通过操作类型 + 脚本名尝试从缓存中获取指定的
     * {@link DefaultRedisScript<LuaOperatorResult>}，没有则从 classpath 中加载然后缓存。
     *
     * @param operatorType  Lua 脚本类型
     * @param luaScriptName Lua 脚本名
     *
     * @return 由 {@link DefaultRedisScript} 包装的，
     *         发布 Lua 脚本执行结果 {@link LuaOperatorResult} 的 {@link Mono}
     */
    private @NotNull Mono<DefaultRedisScript<LuaOperatorResult>>
    getScriptFromCache(LuaScriptOperatorType operatorType, String luaScriptName)
    {
        return
        Mono.fromCallable(() -> {
            ConcurrentMap<String, DefaultRedisScript<LuaOperatorResult>>
                operatorCache = this.getOrCreateScriptCache(operatorType);

            // 调用 computeIfAbsent() 方法，
            // 存在则直接返回，不存在执行 mappingFunction 缓存后再返回。
            return
            operatorCache.computeIfAbsent(
                luaScriptName,
                (scriptName) -> {
                    try
                    {
                        return
                        this.loadFromClassPath(operatorType, luaScriptName);
                    }
                    catch (IOException exception)
                    {
                        throw new
                        LuaScriptOperatorFailed(
                            format(
                                "Load lua script %s failed! Caused by: %s",
                                luaScriptName, exception.getMessage()),
                            exception
                        );
                    }
                }
            );
        });
    }
    /** ... */
}
```

## 2.  为项目内所有 I/O 密集型操作配置统一的调度器

在原来的代码中，没有为 Lua 脚本读取、Lua 脚本执行这样的 I/O 操作配置调度器，
按照响应式架构的设计，对于没有指定调度器的响应式流，订阅后一般由事件循环线程（ioEventLoop）执行，显然让宝贵的事件循环线程去执行 I/O 操作是不合理的，所以我为本项目配置了专用的调度器，如下所示：

```java
    /** Redis Lock 专用的线程调度器 Bean。*/
    @Bean(name = "distributedLockScheduler")
    public Scheduler
    distributedLockScheduler(RedisLockProperties properties)
    {
        RedisLockProperties.ProjectSchedulersProperties
            schedulersProperties = properties.getSchedulers();

        return
        Schedulers.newBoundedElastic(
            schedulersProperties.getMaxThreads(),
            schedulersProperties.getTaskQueueCapacity(),
            schedulersProperties.getThreadName(),
            schedulersProperties.getTtlSeconds(),
            schedulersProperties.isDaemon()
        );
    }
```

用户可以根据自己项目的负载程度在配置中自定义调度器的相关参数，示例如下：

```yml
app:
  redis-lock:
    schedulers:
      # 最大线程数（默认 100 线程）
      max-threads: 100
      # 任务队列容量（默认 1000）
      task-queue-capacity: 1000
      # 调度线程名（默认 redis-lock）
      thread-name: redis-lock
      # 空闲线程存活时间（默认 60 秒）
      ttl-seconds: 60
      # 是否开启守护线程？（对于分布式锁操作来说是必须的）
      daemon: true
```

这个调度器被用在了某些关键的位置，关键代码如下所示：

```java
   /**
     * 尝试获取一个锁。
     *
     * @param lockName          锁名
     * @param acquireTimeout    获取锁的时间期限
     * @param lockTimeout       锁本身的有效期（单位：秒）
     *
     * @return 返回一个 Mono，成功获取锁时发布锁的唯一标识符（UUID）
     */
    private @NotNull Mono<String>
    acquireLockTimeout(
        String lockName, long acquireTimeout, long lockTimeout)
    {
        final String lockKeyName = getRedisLockKey(lockName);
        final String identifier  = UUID.randomUUID().toString();

        return
        this.luaScriptReader
            .read(DISTRIBUTE_LOCK, "acquireLockTimeout.lua") // Lua 脚本执行在指定调度器
            .flatMap((script) ->
                this.scriptRedisTemplate
                    .execute(
                        script,
                        List.of(lockKeyName),
                        identifier, acquireTimeout, lockTimeout)
                    .next()
                    .subscribeOn(this.scheduler) // Lua 脚本执行在指定调度器
                    .flatMap((result) ->
                        switch (result.getResult())
                        {
                            case "GET_LOCK_TIMEOUT" ->
                                Mono.error(
                                    new RedisDistributedLockAcquireTimeout(
                                        format(
                                            "Acquire lock: %s timeout! (acquireTimeout = %d seconds)",
                                            lockName, acquireTimeout
                                        )
                                    )
                                );

                            case "SUCCESS" -> Mono.just(identifier);

                            case null, default ->
                                Mono.error(
                                    new IllegalStateException(
                                        "Unexpected value: " + result.getResult()
                                    )
                                );
                        }
                    )
            ).onErrorResume(RedisLockErrorHandle::redisLockGenericErrorHandle);
    }
```

*2025.11.07*